### PR TITLE
01152022: Add routers and group swagger endpoints by type

### DIFF
--- a/app/routers/post.py
+++ b/app/routers/post.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+from typing import List
+
+
+from app import models, schemas
+from app.database import engine, get_db
+
+
+router = APIRouter(
+    prefix = "/posts",
+    tags = ['Posts']
+)
+
+
+@router.get("/", response_model=List[schemas.ResponsePost])
+def get_posts(db: Session = Depends(get_db), skip: int = 0, limit: int = 100):
+    posts = db.query(models.Post).offset(skip).limit(limit).all()
+    return posts
+
+
+@router.get("/{id}", response_model=schemas.ResponsePost)
+def get_post_by_id(id: int, db: Session = Depends(get_db)):
+    post = db.query(models.Post).filter(models.Post.id == id).first()
+    if not post:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"post with id: {id} was not found")
+    return post
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=schemas.ResponsePost)
+def create_post(post: schemas.CreatePost, db: Session = Depends(get_db)):
+    new_post = models.Post(**post.dict())
+    db.add(new_post)
+    db.commit()
+    db.refresh(new_post)
+    return new_post
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_post(id: int, db: Session = Depends(get_db)):
+    deleted_post = db.query(models.Post).filter(models.Post.id == id).first()
+    if not deleted_post:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"post with id: {id} was not found")
+    db.delete(deleted_post)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put("/{id}", status_code=status.HTTP_202_ACCEPTED, response_model=schemas.ResponsePost)
+def update_post(id: int, updated_post: schemas.PostBase, db: Session = Depends(get_db)):
+    post_query = db.query(models.Post).filter(models.Post.id == id)
+    post = post_query.first()
+    if post == None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"post with id: {id} was not found")
+    post_query.update(updated_post.dict(), synchronize_session = False)
+    db.commit()
+    return post_query.first()

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import models, schemas, utils
+from app.database import engine, get_db
+
+
+router = APIRouter(
+    prefix = "/users",
+    tags = ['Users']
+)
+
+
+@router.get("/{id}", response_model=schemas.UserOut)
+def get_user(id: int, db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.id == id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"user with id: {id} was not found")
+    return  user
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=schemas.UserOut)
+def create_user(user: schemas.CreateUser, db: Session = Depends(get_db)):
+
+    #hash the password - user.password
+    hashed_password = utils.hash(user.password)
+    user.password = hashed_password
+
+    new_user = models.User(**user.dict())
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    return new_user


### PR DESCRIPTION
- Moved path operations from main.py to routers (post.py and user.py)
- Create prefix for post and user so that `/posts` and `/users` doesn't need to be included in the decorator
- Add tags for swagger UI. Posts requests and Users requests are now separated.